### PR TITLE
Fix misplaced variables in Docs.docm (fixes #11348)

### DIFF
--- a/base/docs.jl
+++ b/base/docs.jl
@@ -190,7 +190,7 @@ function docm(meta, def)
     isexpr(def′, :type) && return namedoc(meta, def, namify(def′.args[2]))
     isexpr(def′, :abstract) && return namedoc(meta, def, namify(def′))
     fexpr(def′) && return funcdoc(meta, def)
-    isexpr(def, :macrocall) && (def = namify(def))
+    isexpr(def′, :macrocall) && (def = namify(def′))
     return objdoc(meta, def)
 end
 


### PR DESCRIPTION
In one of the functions that's part of `@doc`, `def` was used instead of
`def′`.
